### PR TITLE
Rename `mozilla-ion` to `mozilla-rally`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla-ion/ion-core-addon/compare/v0.6.1...main)
+[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.1...main)
 
 * #237: Remove reliance on the Firefox Pioner ID pref.
 
 # v0.6.1 (2020-12-09)
 
-[Full changelog](https://github.com/mozilla-ion/ion-core-addon/compare/v0.6.0...main)
+[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.0...main)
 
 * Added this changelog file.
 * The data collected from the demographic survey is being submitted to the Rally servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.1...main)
 
-* #237: Remove reliance on the Firefox Pioner ID pref.
+* [#237](https://github.com/mozilla-rally/core-addon/pull/237): Remove reliance on the Firefox Pioner ID pref.
+* [#262](https://github.com/mozilla-rally/core-addon/pull/262): rename the org from `mozilla-ion` to `mozilla-rally`. Without this change the core add-on won't be able to communicate with the test website.
 
 # v0.6.1 (2020-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.1...main)
+[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.1...master)
 
 * [#237](https://github.com/mozilla-rally/core-addon/pull/237): Remove reliance on the Firefox Pioner ID pref.
 * [#262](https://github.com/mozilla-rally/core-addon/pull/262): rename the org from `mozilla-ion` to `mozilla-rally`. Without this change the core add-on won't be able to communicate with the test website.
 
 # v0.6.1 (2020-12-09)
 
-[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.0...main)
+[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.6.0...master)
 
 * Added this changelog file.
 * The data collected from the demographic survey is being submitted to the Rally servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#237](https://github.com/mozilla-rally/core-addon/pull/237): Remove reliance on the Firefox Pioner ID pref.
 * [#262](https://github.com/mozilla-rally/core-addon/pull/262): rename the org from `mozilla-ion` to `mozilla-rally`. Without this change the core add-on won't be able to communicate with the test website.
+  * This changed the Partner Support Library as well.
 
 # v0.6.1 (2020-12-09)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Ion
+# Rally
 
-This is the Core Add-on for Ion studies. It is implemented as a cross-browser WebExtension, using Svelte for the UI.
+This is the Core Add-on for the Rally platform. It is implemented as a cross-browser WebExtension, using Svelte for the UI.
 
-Ion studies may be implemented as add-ons, or built-in to the Core Add-on. A [demo study add-on](https://github.com/mozilla-ion/demo-study-addon) and [demo website landing page](https://github.com/mozilla-ion/mozilla-ion.github.io) are available.
+Rally studies are implemented as Add-ons. A [study template](https://github.com/mozilla-rally/study-template) is provided to help study authors start writing their study. A [demo website landing page](https://mozilla-rally.github.io/core-addon) is also available for testing the Core Add-on.
 
-The "source of truth" for Ion study metadata is on the [Firefox remote settings server](https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records).
+The "source of truth" for Rally study metadata is on the [Firefox remote settings server](https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records).
 
 ## Get started
 
@@ -71,7 +71,7 @@ The output will be a `.zip` file in `web-ext-artifacts/` - this should be rename
 
 ## Building and testing a study locally
 
-To run an end-to-end local test with your own study add-on, first build your study (if you don't have one, you can [build the Ion Basic Study](https://github.com/mozilla-ion/ion-basic-study)) and export the signed build as `<name-of-study>.xpi`. Edit `/public/locally-available-studies.json` so that `sourceURI.spec` is `/public/<name-of-study>.xpi` (you can change the other fields in `/public/locally-available-studies.json` as well for demo purposes as needed).
+To run an end-to-end local test with your own study add-on, first build your study (if you don't have one, you can [build the Ion Basic Study](https://github.com/mozilla-rally/study-template)) and export the signed build as `<name-of-study>.xpi`. Edit `/public/locally-available-studies.json` so that `sourceURI.spec` is `/public/<name-of-study>.xpi` (you can change the other fields in `/public/locally-available-studies.json` as well for demo purposes as needed).
 
 Then run:
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -78,7 +78,7 @@ fi
 
 FILE=package.json
 run $SED -i.bak -E \
-    -e "s/^\"version\": \"[0-9a-z.-]+\"/\"version\": \"${NEW_VERSION}\"/" \
+    -e "s/\"version\": \"[0-9a-z.-]+\"/\"version\": \"${NEW_VERSION}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
@@ -88,7 +88,7 @@ run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 FILE=manifest.json
 run $SED -i.bak -E \
-    -e "s/^\"version\": \"[0-9a-z.-]+\"/\"version\": \"${NEW_VERSION}\"/" \
+    -e "s/\"version\": \"[0-9a-z.-]+\"/\"version\": \"${NEW_VERSION}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -110,7 +110,7 @@ if [ "$DOIT" = y ]; then
     cat > "${WORKSPACE_ROOT}/${FILE}" <<EOL
 # Unreleased changes
 
-[Full changelog](https://github.com/mozilla-ion/ion-core-addon/compare/v${NEW_VERSION}...master)
+[Full changelog](https://github.com/mozilla-rally/core-addon/compare/v${NEW_VERSION}...master)
 
 ${CHANGELOG}
 EOL
@@ -143,4 +143,4 @@ echo "Don't forget to push this commit:"
 echo
 echo "    git push $remote $branch"
 echo
-echo "Once pushed, wait for the CI build to finish: https://circleci.com/gh/mozilla-ion/ion-core-addon/tree/$branch"
+echo "Once pushed, wait for the CI build to finish: https://circleci.com/gh/mozilla-rally/core-addon/tree/$branch"

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -12,7 +12,7 @@ const ION_DEFAULT_ARGS = {
   // NOTE: if this URL ever changes, you will have to update the domain in
   // the permissions in manifest.json.
   availableStudiesURI: "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records",
-  website: "https://mozilla-ion.github.io",
+  website: "https://mozilla-rally.github.io",
 }
 
 module.exports = class IonCore {

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,11 +1,11 @@
 # Rally Release Process
 The Rally Core Add-on will be shipped as a [browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions), with special Firefox-only privileges.
-In order to enable Firefox-specific privileges it requires a signature done on Mozilla infrastructure, in the [`mozilla-extensions`](https://github.com/mozilla-extensions/ion-core-addon/) clone of [this repository](https://github.com/mozilla-ion/ion-core-addon).
+In order to enable Firefox-specific privileges it requires a signature done on Mozilla infrastructure, in the [`mozilla-extensions`](https://github.com/mozilla-extensions/core-addon/) clone of [this repository](https://github.com/mozilla-rally/core-addon).
 
 The development & release process roughly follows the [GitFlow model](https://nvie.com/posts/a-successful-git-branching-model/).
 
-> **Note:** The rest of this section assumes that `upstream` points to the `https://github.com/mozilla-ion/ion-core-addon` repository,
-> `origin` points to the developer fork and `mozext` refers to `https://github.com/mozilla-extensions/ion-core-addon`.
+> **Note:** The rest of this section assumes that `upstream` points to the `https://github.com/mozilla-rally/core-addon` repository,
+> `origin` points to the developer fork and `mozext` refers to `https://github.com/mozilla-extensions/core-addon`.
 > For some developer workflows, `upstream` can be the same as `origin`.
 
 **Table of Contents**:
@@ -18,7 +18,7 @@ The development & release process roughly follows the [GitFlow model](https://nv
 ## Published artifacts
 
 * A QA-signed version of the Firefox Rally Core Add-on (**only meant for QA**).
-* A Mozilla-signed version of the Firefox Rally Core Add-on ([**TODO**](https://github.com/mozilla-ion/ion-core-addon/issues/242)).
+* A Mozilla-signed version of the Firefox Rally Core Add-on ([**TODO**](https://github.com/mozilla-rally/core-addon/issues/242)).
 
 ## Standard Release
 
@@ -46,7 +46,7 @@ Releases can only be done by one of the project maintainers.
     git push upstream release-v25.0.0
     ```
 5. Wait for CI to finish on that branch and ensure it's green:
-    * <https://circleci.com/gh/mozilla-ion/ion-core-addon/tree/release-v25.0.0>
+    * <https://circleci.com/gh/mozilla-rally/core-addon/tree/release-v25.0.0>
 6. Apply additional commits for bug fixes to this branch.
     * Adding large new features here is strictly prohibited. They need to go to the `master` branch and wait for the next release.
 
@@ -67,13 +67,13 @@ When CI has finished and is green for your specific release branch, you are read
     git push upstream release
     ```
 4. Tag the release on GitHub:
-    1. [Draft a New Release](https://github.com/mozilla-ion/ion-core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
+    1. [Draft a New Release](https://github.com/mozilla-rally/core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
     2. Enter `v<myversion>` as the tag. It's important this is the same as the version you specified to the `prepare_release.sh` script, with the `v` prefix added.
     3. Select the `release` branch as the target.
      4. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
 5. Wait for the CI build to complete for the tag.
-    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-ion/ion-core-addon).
-6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-ion/ion-core-addon/compare/master...release-v25.0.0?expand=1>
+    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-rally/core-addon).
+6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-rally/core-addon/compare/master...release-v25.0.0?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
 7. Once the above pull request lands, delete the specific release branch (e.g. `release-v25.0.0`).
@@ -83,7 +83,7 @@ When CI has finished and is green for your specific release branch, you are read
     git push mozext release
     git push mozext v25.0.0
     ```
-9. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/ion-core-addon/compare/master...release?expand=1>
+9. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/core-addon/compare/master...release?expand=1>
     * Add the description from the `upstream` GitHub release as the description of the PR.
     * Set the title of the PR to `Release 25.0.0`.
     * This is important so that CI runs the signing process.
@@ -114,9 +114,9 @@ If the latest released version requires a bug fix, a hotfix branch is used.
     git checkout -b bugfix hotfix-v25.0.1
     ```
 5. Fix the bug and commit the fix in one or more separate commits.
-6. Push your bug fixes and create a pull request against the hotfix branch: <https://github.com/mozilla-ion/ion-core-addon/compare/hotfix-v25.0.1...your-name:bugfix?expand=1>
+6. Push your bug fixes and create a pull request against the hotfix branch: <https://github.com/mozilla-rally/core-addon/compare/hotfix-v25.0.1...your-name:bugfix?expand=1>
 7. When that pull request lands, wait for CI to finish on that branch and ensure it's green:
-    * <https://circleci.com/gh/mozilla-ion/ion-core-addon/tree/hotfix-v25.0.1>
+    * <https://circleci.com/gh/mozilla-rally/core-addon/tree/hotfix-v25.0.1>
 
 ### Finish a hotfix branch
 
@@ -135,13 +135,13 @@ When CI has finished and is green for your hotfix branch, you are ready to cut a
     git push upstream release
     ```
 4. Tag the release on GitHub:
-    1. [Draft a New Release](https://github.com/mozilla-ion/ion-core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
+    1. [Draft a New Release](https://github.com/mozilla-rally/core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
     2. Enter `v<myversion>` as the tag. It's important this is the same as the version you specified to the `prepare_release.sh` script, with the `v` prefix added.
     3. Select the `release` branch as the target.
     4. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
 5. Wait for the CI build to complete for the tag.
-    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-ion/ion-core-addon).
-6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-ion/ion-core-addon/compare/master...hotfix-v25.0.1?expand=1>
+    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-rally/core-addon).
+6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-rally/core-addon/compare/master...hotfix-v25.0.1?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
 7. Once the above pull request lands, delete the specific hotfix branch (e.g. `hotfix-v25.0.1`).
@@ -151,7 +151,7 @@ When CI has finished and is green for your hotfix branch, you are ready to cut a
     git push mozext release
     git push mozext v25.0.1
     ```
-9. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/ion-core-addon/compare/master...release?expand=1>
+9. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/core-addon/compare/master...release?expand=1>
     * Add the description from the `upstream` GitHub release as the description of the PR.
     * Set the title of the PR to `Release 25.0.1`.
     * This is important so that CI runs the signing process.
@@ -178,9 +178,9 @@ If you need to release a hotfix for a previously released version (that is: not 
     git checkout -b hotfix-v24.0.1 support/v24.0
     ```
 3. Fix the bug and commit the fix in one or more separate commits into your hotfix branch.
-4. Push your bug fixes and create a pull request against the support branch: <https://github.com/mozilla-ion/ion-core-addon/compare/support/v24.0...your-name:hotfix-v24.0.1?expand=1>
+4. Push your bug fixes and create a pull request against the support branch: <https://github.com/mozilla-rally/core-addon/compare/support/v24.0...your-name:hotfix-v24.0.1?expand=1>
 5. When that pull request lands, wait for CI to finish on that branch and ensure it's green:
-    * <https://circleci.com/gh/mozilla-ion/ion-core-addon/tree/support/v24.0>
+    * <https://circleci.com/gh/mozilla-rally/core-addon/tree/support/v24.0>
 
 ### Finish a support branch
 
@@ -199,13 +199,13 @@ If you need to release a hotfix for a previously released version (that is: not 
     git push upstream support/v24.0
     ```
 4. Tag the release on GitHub:
-    1. [Draft a New Release](https://github.com/mozilla-ion/ion-core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
+    1. [Draft a New Release](https://github.com/mozilla-rally/core-addon/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
     2. Enter `v<myversion>` as the tag. It's important this is the same as the version you specified to the `prepare_release.sh` script, with the `v` prefix added.
     3. Select the support branch (e.g. `support/v24.0`) as the target.
     4. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
 5. Wait for the CI build to complete for the tag.
-    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-ion/ion-core-addon).
-6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-ion/ion-core-addon/compare/master...support/v24.0?expand=1>
+    * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla-rally/core-addon).
+6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-rally/core-addon/compare/master...support/v24.0?expand=1>
     * This is important so that no changes are lost.
     * This might have merge conflicts with the `master` branch, which you need to fix before it is merged.
 7. Mirror the release branch and the release tag on the signing repository:
@@ -214,7 +214,7 @@ If you need to release a hotfix for a previously released version (that is: not 
     git push mozext support/v24.0
     git push mozext v24.0
     ```
-8. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/ion-core-addon/compare/master...support/v24.0?expand=1>
+8. Trigger the signing process by sending a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla-extensions/core-addon/compare/master...support/v24.0?expand=1>
     * Add the description from the `upstream` GitHub release as the description of the PR.
     * This is important so that CI runs the signing process.
     * This should never have conflicts with `master` branch: no change should ever happen on this repository outside from the mirroring and merging.

--- a/docs/STUDY_PUBLISHING.md
+++ b/docs/STUDY_PUBLISHING.md
@@ -6,7 +6,7 @@ Create account on https://addons.mozilla.org, navigate to the "Developer Hub", a
 
 ## Build your extension
 
-Starting with a github repository containing your study extension (such as [the Ion Basic Study](https://github.com/mozilla-ion/ion-basic-study)):
+Starting with a github repository containing your study extension (such as [the Ion Basic Study](https://github.com/mozilla-rally/study-template)):
 
 * run `web-ext build` to generate your extension in `web-ext-artifacts/`
 * upload the resulting `.zip` file in `web-ext-artifacts/` to the https://addons.mozilla.org Developer Hub
@@ -17,7 +17,7 @@ It may take some time for your extension to be reviewed and available for downlo
 
 The Ion Core extension checks the Firefox RemoteSettings server for a list of the currently-approved studies.
 
-For local testing, see: https://github.com/mozilla-ion/ion-core-addon#building-and-testing-a-study-locally
+For local testing, see: https://github.com/mozilla-rally/core-addon#building-and-testing-a-study-locally
 There is also a RemoteSettings dev server you may use for local testing / QA: https://remote-settings.readthedocs.io/en/latest/tutorial-dev-server.html
 
 Updates to the staging and production RemoteSettings servers must receive sign off. The current reviewers are @knowtheory and @rhelmer.

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,7 +202,7 @@
     <a
       id="installButton"
       tabindex="0"
-      href="https://github.com/mozilla-ion/ion-core-addon/releases/download/v0.6.1/ion_core-0.6.0-signed.xpi"
+      href="https://github.com/mozilla-rally/core-addon/releases/download/v0.6.1/ion_core-0.6.0-signed.xpi"
       >Install the Ion Web Extension</a
     >
     <div id="installedBlob" style="display: none;">
@@ -212,7 +212,7 @@
       <b style="text-transform: uppercase;">Note</b> – this installs the latest
       development version of Ion. We do our best to keep this stable and
       up-to-date, please file
-      <a href="https://github.com/mozilla-ion/ion-core-addon/issues/new"
+      <a href="https://github.com/mozilla-rally/core-addon/issues/new"
         >an issue on github</a
       >
       for any problems you encounter. Thanks for dogfooding!

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "description": "Ion Core add-on.",
+  "description": "Rally Core add-on.",
   "author": "Mozilla",
   "manifest_version": 2,
   "name": "Ion Core",
@@ -44,7 +44,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://mozilla-ion.github.io/*"],
+      "matches": ["https://mozilla-rally.github.io/*"],
       "js": ["public/addon-build/content-script.js"]
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ion_core",
+  "name": "rally_core",
   "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ion_core",
+  "name": "rally_core",
   "version": "0.6.0",
   "scripts": {
     "build": "rollup -c && rollup -c rollup.config.addon.js --config-study-list-url=/public/locally-available-studies.json && web-ext build --overwrite-dest && mv web-ext-artifacts/*.zip web-ext-artifacts/ion_core.xpi",
@@ -66,14 +66,14 @@
   "description": "This is the Ion Core Add-on: a cross-browser WebExtension that allows users to participate to Ion studies.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla-ion/ion-core-addon.git"
+    "url": "git+https://github.com/mozilla-rally/core-addon.git"
   },
   "keywords": [],
   "author": "Mozilla",
   "license": "MPL-2.0",
   "private": true,
   "bugs": {
-    "url": "https://github.com/mozilla-ion/ion-core-addon/issues"
+    "url": "https://github.com/mozilla-rally/core-addon/issues"
   },
-  "homepage": "https://github.com/mozilla-ion/ion-core-addon#readme"
+  "homepage": "https://github.com/mozilla-rally/core-addon#readme"
 }

--- a/public/rally.css
+++ b/public/rally.css
@@ -230,7 +230,7 @@ ul.mzp-u-list-styled {
 
 We'll use these global styles until we can assure use of :global in Svelte components again.
 
-See #141: https://github.com/mozilla-ion/ion-core-addon/issues/141
+See #141: https://github.com/mozilla-rally/core-addon/issues/141
 
 */
 

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -20,7 +20,7 @@ export default (cliArgs) => {
           "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
         __ION_WEBSITE_URL__: cliArgs['config-website'] ?
           `'${cliArgs['config-website']}'` :
-          "'https://mozilla-ion.github.io'",
+          "'https://mozilla-rally.github.io'",
       }),
       resolve({
         browser: true,

--- a/src/routes/current-studies/StudyCard.svelte
+++ b/src/routes/current-studies/StudyCard.svelte
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
  // ^^^ the linter currently forces this block even though it appears below.
- // see https://github.com/mozilla-ion/ion-core-addon/issues/184.
+ // see https://github.com/mozilla-rally/core-addon/issues/184.
 import { writable, get } from 'svelte/store';
 
 let notificationID = writable(undefined);

--- a/support/README.md
+++ b/support/README.md
@@ -2,4 +2,4 @@
 
 This is the Rally partner support library, `Rally.js`, used to manage the lifecycle of Rally studies.
 
-This library is used in the [Rally Study Template](https://github.com/mozilla-ion/ion-basic-study).
+This library is used in the [Rally Study Template](https://github.com/mozilla-rally/study-template).

--- a/support/package.json
+++ b/support/package.json
@@ -10,14 +10,14 @@
   "dependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla-ion/ion-core-addon.git",
+    "url": "git+https://github.com/mozilla-rally/core-addon.git",
     "directory": "support"
   },
   "keywords": [],
   "author": "Mozilla Rally team",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/mozilla-ion/ion-core-addon/issues"
+    "url": "https://github.com/mozilla-rally/core-addon/issues"
   },
-  "homepage": "https://github.com/mozilla-ion/ion-core-addon#readme"
+  "homepage": "https://github.com/mozilla-rally/core-addon#readme"
 }

--- a/support/rally.js
+++ b/support/rally.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 const CORE_ADDON_ID = "ion-core-addon@mozilla.org";
-const ION_SIGNUP_URL = "https://mozilla-ion.github.io/ion-core-addon/";
+const SIGNUP_URL = "https://mozilla-rally.github.io/core-addon/";
 
 module.exports = class Rally {
   /**
@@ -35,7 +35,7 @@ module.exports = class Rally {
     await this._checkRallyCore().then(
         () => console.debug("Rally.initialize - Found the Core Add-on")
       ).catch(
-        async () => await browser.tabs.create({ url: ION_SIGNUP_URL })
+        async () => await browser.tabs.create({ url: SIGNUP_URL })
       );
 
     // Listen for incoming messages from the Core addon.

--- a/tests/core-addon/integration/core_addon.js
+++ b/tests/core-addon/integration/core_addon.js
@@ -86,10 +86,10 @@ describe("Core-Addon Onboarding", function () {
     await this.driver.wait(until.elementLocated(By.css("button")));
 
     // FIXME we need to use button IDs here so xpath is not needed...
-    // See https://github.com/mozilla-ion/ion-core-addon/issues/244
+    // See https://github.com/mozilla-rally/core-addon/issues/244
     await findAndAct(this.driver, By.xpath(`//button[text()="Get Started"]`), e => e.click());
     await findAndAct(this.driver, By.xpath(`//button[text()="Accept & Participate"]`), e => e.click());
-    // TODO check that state is enrolled, see https://github.com/mozilla-ion/ion-core-addon/issues/245
+    // TODO check that state is enrolled, see https://github.com/mozilla-rally/core-addon/issues/245
 
     await findAndAct(this.driver, By.xpath(`//button[text()="Save & Continue"]`), e => e.click());
 
@@ -108,7 +108,7 @@ describe("Core-Addon Onboarding", function () {
     // FIXME close tab and click on icon, check that post-enrollment options page is shown.
     // This will currently fail because there is a bug in the core-addon UI, where
     // the options page will show no studies.
-    // See https://github.com/mozilla-ion/ion-core-addon/issues/235
+    // See https://github.com/mozilla-rally/core-addon/issues/235
 
     // Switch back to web content context.
     await this.driver.setContext(firefox.Context.CONTENT);
@@ -134,6 +134,6 @@ describe("Core-Addon Onboarding", function () {
     );
     await this.driver.wait(until.elementIsVisible(confirmButton), WAIT_FOR_PROPERTY);
     confirmButton.click();
-    // TODO check that core add-on is uninstalled, see https://github.com/mozilla-ion/ion-core-addon/issues/245
+    // TODO check that core add-on is uninstalled, see https://github.com/mozilla-rally/core-addon/issues/245
   });
 });

--- a/tests/core-addon/integration/core_addon.js
+++ b/tests/core-addon/integration/core_addon.js
@@ -100,8 +100,6 @@ describe("Core-Addon Onboarding", function () {
     // Switch to browser UI context, to interact with Firefox add-on install prompts.
 
     await this.driver.setContext(firefox.Context.CHROME);
-    await findAndAct(this.driver, By.css(`[label="Continue to Installation"]`), e => e.click());
-
     await findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
     await findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
 


### PR DESCRIPTION
This contributes to mozilla-rally/internal#18

Note that this will require cutting a new release of the Core Add-on and a new release of the partner support library. Then, we'll need a new release of the study example, too.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
