### PR TITLE
Perform full matching on the version string

### DIFF
--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -43,7 +43,7 @@ fi
 NEW_VERSION="$1"
 DATE=$(date +%Y-%m-%d)
 
-if ! echo "$NEW_VERSION" | grep --quiet --extended-regexp '^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.-]+)?'; then
+if ! echo "$NEW_VERSION" | grep --quiet --extended-regexp '^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.-]+)?$'; then
     echo "error: Specified version '${NEW_VERSION}' doesn't match the Semantic Versioning pattern."
     echo "error: Use MAJOR.MINOR.PATCH versioning."
     echo "error: See https://semver.org/"


### PR DESCRIPTION
This prevents trailing characters from accidentally making it into the version string.

See [here](https://github.com/mozilla/glean/pull/1399#discussion_r544978500).

I'm not adding a changelog entry, this is an internal-only change.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
