### PR TITLE
Restrict to the `en-US` locale

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
     __API_ENDPOINT__: false,
     __ION_STUDIES_LIST__: false,
     __ION_WEBSITE_URL__: false,
-    __STORE_IMPLEMENTATION__: false,
+    __DISABLE_LOCALE_CHECK__: false,
   },
   overrides: [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Core-Addon
   * [#294](https://github.com/mozilla-rally/core-addon/pull/294): Only process messages from known, installed studies. Additionally rename `ionInstalled` to `studyInstalled`.
   * [#301](https://github.com/mozilla-rally/core-addon/pull/301): Correctly report the zip code in the demographics survey.
+  * [#298](https://github.com/mozilla-rally/core-addon/pull/298): Disable Rally on locales other than `en-US`. The ` --config-disable-locale-check` build option allows overriding the check for developer workflows on other locales.
 
 # v0.7.1 (2021-01-13)
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,7 @@ function serve() {
   };
 }
 
-export default {
+export default (cliArgs) => [{
   input: "src/main.js",
   output: {
     sourcemap: true,
@@ -51,6 +51,9 @@ export default {
       // the following replacements build the site URLs.
       // In the templates, use (for example) __BASE_SITE_URL__/__FAQ_PATH__
       __BASE_SITE__: "https://rally-stage.bespoke.nonprod.dataops.mozgcp.net",
+      // Support enabling/disabling the locale check to enable
+      // the development workflows on other locales.
+      __DISABLE_LOCALE_CHECK__: !!cliArgs["config-disable-locale-check"],
     }),
     copy({
       targets: [
@@ -99,4 +102,4 @@ export default {
   watch: {
     clearScreen: false,
   },
-};
+}];

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,25 +16,36 @@
   $: if ($store && firstRun === undefined) {
     firstRun = !$store.enrolled;
   }
+
+  // We currently exclusively support Rally on en-US locales,
+  // but still support enabling/disabling the locale check
+  // to enable the development workflows on other locales.
+  let isRallySupported = __DISABLE_LOCALE_CHECK__
+    ? true
+    : navigator.language === "en-US";
 </script>
 
-{#if $store}
-  {#if firstRun}
-    <!-- onboarding flow -->
-    <!-- the onboarding-complete event occurs once the user has
-    gotten through the profile completion step. -->
-    <Onboarding
-      on:onboarding-complete={() => {
-        firstRun = false;
-      }} />
-  {:else}
-    <!-- main application flow -->
-    <Main
-        on:leave-rally={() => {
-          store.updatePlatformEnrollment(false);
-          // reset to first run until Rally uninstalls itself.
-          firstRun = true;
-        }}
-      />
+{#if isRallySupported}
+  {#if $store}
+    {#if firstRun}
+      <!-- onboarding flow -->
+      <!-- the onboarding-complete event occurs once the user has
+      gotten through the profile completion step. -->
+      <Onboarding
+        on:onboarding-complete={() => {
+          firstRun = false;
+        }} />
+    {:else}
+      <!-- main application flow -->
+      <Main
+          on:leave-rally={() => {
+            store.updatePlatformEnrollment(false);
+            // reset to first run until Rally uninstalls itself.
+            firstRun = true;
+          }}
+        />
+    {/if}
   {/if}
+{:else}
+  <div>Sorry, Rally is not supported in this locale.</div>
 {/if}

--- a/tests/core-addon/integration/utils.js
+++ b/tests/core-addon/integration/utils.js
@@ -11,12 +11,21 @@ const fs = require("fs");
  *
  * @param {Boolean} headless
  *        Whether or not to run Firefox in headless mode.
+ * @param {Object} prefsOverride
+ *        The properties of this object are a key-value
+ *        representation of the preferences to set.
  * @returns {WebDriver} a WebDriver instance to control Firefox.
  */
-async function getFirefoxDriver(headless) {
+async function getFirefoxDriver(headless, prefsOverride) {
   const firefoxOptions = new firefox.Options();
   firefoxOptions.setPreference("xpinstall.signatures.required", false);
   firefoxOptions.setPreference("extensions.experiments.enabled", true);
+
+  if (prefsOverride) {
+    for (let [pref, value] of Object.entries(prefsOverride)) {
+      firefoxOptions.setPreference(pref, value);
+    }
+  }
 
   if (headless) {
     firefoxOptions.headless();


### PR DESCRIPTION
Fixes #263 

This prevents the onboarding flow and allows easy development of the page to be displayed in case of UI restrictions. The background script and operations are still initialized: the core script will respond to uninstall requests from the UI.

#297 will take care of implementing the full UI.

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
