### PR TITLE
Fix zipCode submission in the demographics survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Core-Addon
   * [#294](https://github.com/mozilla-rally/core-addon/pull/294): Only process messages from known, installed studies. Additionally rename `ionInstalled` to `studyInstalled`.
+  * [#301](https://github.com/mozilla-rally/core-addon/pull/301): Correctly report the zip code in the demographics survey.
 
 # v0.7.1 (2021-01-13)
 

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -186,7 +186,6 @@ module.exports = class DataCollection {
       "hispanicLatinoSpanishOrigin": "origin",
       "school": "education",
       "income": "income",
-      "zipCode": "zipCode",
     };
 
     // Important: the following code flattens out arrays and nested
@@ -216,6 +215,12 @@ module.exports = class DataCollection {
     // values.
     if ("race" in data) {
       processed["races"] = data.race.reduce((a, b) => ((a[b] = true), a), {});
+    }
+
+    // Note: "zipcode" gets renamed to "zipCode" and directly
+    // assigned a value.
+    if ("zipcode" in data) {
+      processed["zipCode"] = data["zipcode"];
     }
 
     return await this.sendPing(

--- a/tests/core-addon/unit/DataCollection.test.js
+++ b/tests/core-addon/unit/DataCollection.test.js
@@ -191,7 +191,7 @@ describe('DataCollection', function () {
       assert.equal(submitArgs[2].schemaNamespace, "pioneer-core");
     });
 
-    it('submits demographic-survey ping with races data', async function () {
+    it('submits demographic-survey ping with races and zip data', async function () {
       // Create a mock for the telemetry API.
       chrome.firefoxPrivilegedApi = {
         submitEncryptedPing: async function(type, payload, options) {},
@@ -205,16 +205,19 @@ describe('DataCollection', function () {
       await this.dataCollection.sendDemographicSurveyPing("some-rally-id", {
         "age": "35_44",
         "race": ["american_indian_or_alaska_native", "samoan"],
+        "zipcode": "03295",
       });
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
       assert.equal(submitArgs[0], "pioneer-study");
-      // ... with the "age" and "races" ...
-      assert.equal(Object.keys(submitArgs[1]).length, 2);
+      // ... with the "age", "races" and "zipcode" ...
+      assert.equal(Object.keys(submitArgs[1]).length, 3);
       assert.ok("races" in submitArgs[1]);
       assert.equal(true, submitArgs[1]["races"]["american_indian_or_alaska_native"]);
       assert.equal(true, submitArgs[1]["races"]["samoan"]);
+      assert.ok("zipCode" in submitArgs[1]);
+      assert.equal("03295", submitArgs[1]["zipCode"]);
       // ... and a specific set of options.
       assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");


### PR DESCRIPTION
The data submission code was attempting to submit a field with the wrong name. Moreover, the data from the zipCode should be directly copied rather than attempted to be normalized. This PR additionally adds test coverage for this new field.

Fixes #256 

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [x] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [x] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
