### PR TITLE
Disable data submission to enable safer QA

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     __ION_STUDIES_LIST__: false,
     __ION_WEBSITE_URL__: false,
     __DISABLE_LOCALE_CHECK__: false,
+    __ENABLE_DATA_SUBMISSION__: false,
   },
   overrides: [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * [#294](https://github.com/mozilla-rally/core-addon/pull/294): Only process messages from known, installed studies. Additionally rename `ionInstalled` to `studyInstalled`.
   * [#301](https://github.com/mozilla-rally/core-addon/pull/301): Correctly report the zip code in the demographics survey.
   * [#298](https://github.com/mozilla-rally/core-addon/pull/298): Disable Rally on locales other than `en-US`. The ` --config-disable-locale-check` build option allows overriding the check for developer workflows on other locales.
+  * [#305](https://github.com/mozilla-rally/core-addon/pull/305): Disable data submission to enable safer QA.
 
 # v0.7.1 (2021-01-13)
 

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -155,6 +155,11 @@ module.exports = class DataCollection {
       schemaNamespace: namespace,
     };
 
+    if (!__ENABLE_DATA_SUBMISSION__) {
+      console.warn(`DataCollection.sendPing - data submission disabled, ping ${payloadType} not submitted`);
+      return;
+    }
+
     // We intentionally don't wait on the promise returned by
     // `submitExternalPing`, because that's an internal API only meant
     // for telemetry tests. Moreover, in order to send a custom schema

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,6 +54,10 @@ export default (cliArgs) => [{
       // Support enabling/disabling the locale check to enable
       // the development workflows on other locales.
       __DISABLE_LOCALE_CHECK__: !!cliArgs["config-disable-locale-check"],
+      // Data submission is disabled by default. Use this option via the CLI
+      // to enable it for testing until https://github.com/mozilla-rally/core-addon/issues/304
+      // is fixed.
+      __ENABLE_DATA_SUBMISSION__: !!cliArgs["config-enable-data-submission"],
     }),
     copy({
       targets: [

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -15,10 +15,16 @@ exports.mochaHooks = {
   beforeAll() {
     global.chrome = chrome;
     global.browser = browser;
+    // TODO: remove the next line once https://github.com/mozilla-rally/core-addon/issues/304
+    // is merged.
+    global.__ENABLE_DATA_SUBMISSION__ = true;
   },
   afterAll() {
     chrome.flush();
     delete global.chrome;
     delete global.browser;
+    // TODO: remove the next line once https://github.com/mozilla-rally/core-addon/issues/304
+    // is merged.
+    delete global.__ENABLE_DATA_SUBMISSION__;
   },
 };


### PR DESCRIPTION
This PR disables data submission by default. The core-addon will now log the content of the payload that would be submitted to the console. It additionally introduces a built-time option to enable submission, just to allow local testing.

Note that this fixes #303 and needs to be rebased after #298 is merged.

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
