### PR TITLE
Introduce a developer mode for Rally.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * [#301](https://github.com/mozilla-rally/core-addon/pull/301): Correctly report the zip code in the demographics survey.
   * [#298](https://github.com/mozilla-rally/core-addon/pull/298): Disable Rally on locales other than `en-US`. The ` --config-disable-locale-check` build option allows overriding the check for developer workflows on other locales.
   * [#305](https://github.com/mozilla-rally/core-addon/pull/305): Disable data submission to enable safer QA.
+* `rally.js`
+  * [#306](https://github.com/mozilla-rally/core-addon/pull/306): Add a developer mode. When enabled it allows developer to dump the content of pings to the browser console and prevents the Rally information page to be opened if no core-addon is found.
 
 # v0.7.1 (2021-01-13)
 

--- a/support/package-lock.json
+++ b/support/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/support/package.json
+++ b/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "The Rally partner support library.",
   "main": "rally.js",
   "scripts": {

--- a/support/rally.js
+++ b/support/rally.js
@@ -35,7 +35,7 @@ class Rally {
 
     this._keyId = keyId;
     this._key = key;
-    this._enableDevMode = !!enableDevMode;
+    this._enableDevMode = Boolean(enableDevMode);
 
     await this._checkRallyCore().then(
         () => console.debug("Rally.initialize - Found the Core Add-on")


### PR DESCRIPTION
When the developer mode is enabled a study does not complain if no core-addon is found. It additionally
dumps the contents of any study submitted ping to the browser console, for easier inspection.

This is the first step to help with mozilla-rally/study-template#16 and mozilla-rally/study-template#35.

After this PR is merged:

- [ ] Push the updated version on NPM.
- [ ] Update the version in the study-template.
- [ ]  Enable a `npm run dev` in the study template.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
